### PR TITLE
for #30, support dynamic imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.idea

--- a/crates/starlight/src/bytecompiler.rs
+++ b/crates/starlight/src/bytecompiler.rs
@@ -486,8 +486,9 @@ impl ByteCompiler {
 
         let fm = cm.new_source_file(FileName::Custom("<anonymous>".into()), body);
 
+
         let mut parser = Parser::new(
-            Syntax::Es(Default::default()),
+            Syntax::Es(init_es_config()),
             StringInput::from(&*fm),
             None,
         );

--- a/crates/starlight/src/vm.rs
+++ b/crates/starlight/src/vm.rs
@@ -336,8 +336,9 @@ impl Runtime {
 
         let fm = cm.new_source_file(FileName::Custom(name.into()), script.into());
 
+
         let mut parser = Parser::new(
-            Syntax::Es(Default::default()),
+            Syntax::Es(init_es_config()),
             StringInput::from(&*fm),
             None,
         );
@@ -397,7 +398,7 @@ impl Runtime {
             let fm = cm.new_source_file(FileName::Custom("<script>".into()), script.into());
 
             let mut parser = Parser::new(
-                Syntax::Es(Default::default()),
+                Syntax::Es(init_es_config()),
                 StringInput::from(&*fm),
                 None,
             );
@@ -464,7 +465,7 @@ impl Runtime {
             let fm = cm.new_source_file(FileName::Custom("<script>".into()), script.into());
 
             let mut parser = Parser::new(
-                Syntax::Es(Default::default()),
+                Syntax::Es(init_es_config()),
                 StringInput::from(&*fm),
                 None,
             );
@@ -881,7 +882,7 @@ pub fn parse(script: &str, strict_mode: bool) -> Result<Program, Error> {
     let fm = cm.new_source_file(FileName::Custom("<script>".into()), script.into());
 
     let mut parser = Parser::new(
-        Syntax::Es(Default::default()),
+        Syntax::Es(init_es_config()),
         StringInput::from(&*fm),
         None,
     );
@@ -898,4 +899,10 @@ pub fn parse(script: &str, strict_mode: bool) -> Result<Program, Error> {
     };
 
     Ok(script)
+}
+
+pub(crate) fn init_es_config() -> EsConfig {
+    let mut es_config: EsConfig = Default::default();
+    es_config.dynamic_import = true;
+    es_config
 }


### PR DESCRIPTION
Created util method to init an EsConfig object to support dynamic import statements

see #30

instead of
```SyntaxError: 'import', and 'export' cannot be used outside of module code```
you now get
```ReferenceError: Property 'import' not found```
which lets us define a custom import function